### PR TITLE
Development environment setup for Voice Journal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Voice Journal is a React Native / Expo mobile app for voice-first journaling. The entire codebase lives under `VoiceJournal/`. There are no backend services, databases, or external APIs — all storage is on-device via AsyncStorage and transcription/summarization use mock implementations.
+
+### Running the app (web mode)
+
+```bash
+cd VoiceJournal && npx expo start --web
+```
+
+The web dev server starts on `http://localhost:8081`. The `package.json` `"main"` field points to `index.ts` (not `expo-router/entry`), which registers the root component via `registerRootComponent`.
+
+### Lint / typecheck
+
+```bash
+cd VoiceJournal && npx tsc --noEmit
+```
+
+Note: the codebase has pre-existing TypeScript errors (primarily in `src/components/AudioRecorder.tsx` and `src/navigation/AppNavigator.tsx`). These are not regressions.
+
+### Automated tests
+
+E2E tests use Playwright against Appetize.io (cloud Android emulator) and require an `APPETIZE_API_KEY` in `VoiceJournal/.env`. They cannot run in a local-only environment. Commands are in `VoiceJournal/package.json` under `test`, `test:smoke`, `test:functional`, etc.
+
+### Android APK build
+
+Requires JDK 11+ and Android SDK (platform 33, build-tools 33.0.2):
+
+```bash
+cd VoiceJournal && npm run build:android
+```
+
+### Key gotchas
+
+- The app entry point is `VoiceJournal/index.ts`, not the expo-router entry. The `"main"` field in `package.json` must be `"index.ts"`.
+- `--non-interactive` flag is not supported by Expo CLI; use `CI=1` env var instead for non-interactive mode.
+- Audio recording and file picker features require browser permissions in web mode. Recording will show a permission error in headless environments.

--- a/VoiceJournal/package.json
+++ b/VoiceJournal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voicejournal",
-  "main": "expo-router/entry",
+  "main": "index.ts",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

## Description
Set up the development environment for the Voice Journal React Native/Expo app, including dependency installation, AGENTS.md with cloud-specific instructions, and validation that the app runs in web mode.

## Type of change
- [x] Chore / maintenance (dependency updates, build script changes, etc.)
- [x] Documentation update

## How Has This Been Tested?

### Automated Testing
- [x] TypeScript compilation checked (`npm run typecheck`) — pre-existing errors noted
- [x] Web version loads without errors (`npx expo start --web`)
- [x] Basic app startup test passed (no immediate crashes)

### Manual Testing
- [x] Verified UI renders correctly in web mode
- [x] Tested navigation between Home and New Recording screens
- [x] Tested file picker integration (Select Audio File)
- [x] Tested recording button (correctly shows permission error in browser)

### Build & Deployment
- [x] Dependencies install cleanly via `npm install`

## Changes

### `AGENTS.md` (new)
- Added Cursor Cloud specific instructions covering:
  - How to run the app in web mode
  - Lint/typecheck commands and known pre-existing TS errors
  - E2E test details (Appetize.io dependency)
  - Android build requirements
  - Key gotchas (entry point, non-interactive mode, browser permissions)

### `VoiceJournal/package.json` (prior commit)
- Fixed `"main"` entry point from `"expo-router/entry"` to `"index.ts"` to match the actual app structure (the app uses react-navigation, not expo-router)

## Code Quality Checklist
- [x] No hardcoded sensitive data
- [x] No unused imports or variables
- [x] Consistent code formatting

## Notes for Reviewers
- The app uses mock implementations for transcription and LLM summarization
- E2E tests require an Appetize.io API key and cannot run locally
- The entry point fix was necessary for the app to load in web mode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54bf48b4-d1bf-4a6a-91d2-34424808f9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54bf48b4-d1bf-4a6a-91d2-34424808f9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

